### PR TITLE
Update README example: action @v1.4 and checkout @v7

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ jobs:
   build:
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - uses: microsoft/microsoft-store-apppublisher@v1.4
     - run: msstore reconfigure --tenantId ${{ secrets.PARTNER_CENTER_TENANT_ID }} --sellerId ${{ secrets.PARTNER_CENTER_SELLER_ID }} --clientId ${{ secrets.PARTNER_CENTER_CLIENT_ID }} --clientSecret ${{ secrets.PARTNER_CENTER_CLIENT_SECRET }}
     - run: msstore apps list

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ jobs:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v5
-    - uses: microsoft/microsoft-store-apppublisher@v1.2
+    - uses: microsoft/microsoft-store-apppublisher@v1.4
     - run: msstore reconfigure --tenantId ${{ secrets.PARTNER_CENTER_TENANT_ID }} --sellerId ${{ secrets.PARTNER_CENTER_SELLER_ID }} --clientId ${{ secrets.PARTNER_CENTER_CLIENT_ID }} --clientSecret ${{ secrets.PARTNER_CENTER_CLIENT_SECRET }}
     - run: msstore apps list
 ```


### PR DESCRIPTION
Updates the GitHub Action usage example in the README ahead of cutting the v1.4 release:
- microsoft/microsoft-store-apppublisher `@v1.2` -> `@v1.4`
- ctions/checkout `@v5` -> `@v7` (matches the bump in #341)

Follow-up to #341 (Node 24 + @actions/* majors + esbuild packaging).