### PR TITLE
Route CI npm installs through authenticated Azure Artifacts feed

### DIFF
--- a/.pipelines/build.yml
+++ b/.pipelines/build.yml
@@ -134,6 +134,7 @@ extends:
             image: ubuntu-latest
             os: linux
           steps:
+            - checkout: self
             - download: current
               displayName: Download Signed Artifact
               artifact: vsix

--- a/.pipelines/build.yml
+++ b/.pipelines/build.yml
@@ -47,6 +47,12 @@ extends:
           os: linux
         steps:
         - checkout: self
+        - script: cp $(Build.SourcesDirectory)/.pipelines/release.npmrc $(Build.SourcesDirectory)/.npmrc
+          displayName: Copy .npmrc
+        - task: npmAuthenticate@0
+          displayName: Authenticate npm to feed
+          inputs:
+            workingFile: '$(Build.SourcesDirectory)/.npmrc'
         - script: npm install -g tfx-cli
           displayName: Install TFX
         - script: npm install
@@ -135,8 +141,16 @@ extends:
               displayName: 'Install Node.js 24.x'
               inputs:
                 versionSpec: '24.x'
+            - script: cp $(Build.SourcesDirectory)/.pipelines/release.npmrc $(Build.SourcesDirectory)/.npmrc
+              displayName: Copy .npmrc
+            - task: npmAuthenticate@0
+              displayName: Authenticate npm to feed
+              inputs:
+                workingFile: '$(Build.SourcesDirectory)/.npmrc'
             - task: TfxInstaller@5
               displayName: 'Install TFX CLI'
+              env:
+                NPM_CONFIG_GLOBALCONFIG: $(Build.SourcesDirectory)/.npmrc
               inputs:
                 version: '0.*'
                 checkLatest: true

--- a/.pipelines/release.npmrc
+++ b/.pipelines/release.npmrc
@@ -1,0 +1,2 @@
+registry=https://pkgs.dev.azure.com/microsoft/Pax/_packaging/MSStore.CLI_PublicPackages/npm/registry/
+always-auth=true


### PR DESCRIPTION
## Summary
Routes pipeline npm installs through the internal `MSStore.CLI_PublicPackages` Azure Artifacts feed instead of the public npm registry, with proper authentication wired up in both pipeline jobs.

## Changes
- **`.pipelines/release.npmrc`** (new): points npm at the Azure Artifacts feed with `always-auth=true`.
- **Build job (`BuildAndTest`)**: copy `release.npmrc` → `.npmrc`, then run `npmAuthenticate@0` before the npm installs so the feed is authenticated.
- **Publish job (`PublishToMarketplaceJob`)**:
  - Added the missing `copy .npmrc` step so `npmAuthenticate@0` has a real file to authenticate (it errors on a non-existent `workingFile`).
  - Fixed the `TfxInstaller@5` step to use `env:` instead of an invalid `variables:` step property for `NPM_CONFIG_GLOBALCONFIG` (the `variables:` form fails Azure Pipelines YAML validation).

## Notes
- `build.yml` validated as syntactically valid YAML.
- `release.npmrc` cleaned up (no trailing whitespace / whitespace-only line, trailing newline added).