### PR TITLE
Point global tfx-cli install at authenticated .npmrc

### DIFF
--- a/.pipelines/build.yml
+++ b/.pipelines/build.yml
@@ -53,7 +53,7 @@ extends:
           displayName: Authenticate npm to feed
           inputs:
             workingFile: '$(Build.SourcesDirectory)/.npmrc'
-        - script: npm install -g tfx-cli
+        - script: npm install -g tfx-cli --globalconfig $(Build.SourcesDirectory)/.npmrc
           displayName: Install TFX
         - script: npm install
           displayName: Install Dependencies


### PR DESCRIPTION
## Summary
Follow-up to #343. That PR wired up authentication for the Azure Artifacts feed, but missed one case: the `Install TFX` step in the build job runs `npm install -g tfx-cli`.

`npm install -g` runs in **global mode**, and npm [does not read the per-project `.npmrc`](https://docs.npmjs.com/cli/v9/configuring-npm/npmrc/) in that mode. So despite the preceding `npmAuthenticate@0` step, the global tfx-cli install would hit the private feed **unauthenticated** and fail.

## Change
Pass `--globalconfig $(Build.SourcesDirectory)/.npmrc` to the global install so it uses the authenticated config.

```diff
-        - script: npm install -g tfx-cli
+        - script: npm install -g tfx-cli --globalconfig $(Build.SourcesDirectory)/.npmrc
           displayName: Install TFX
```

This mirrors the `NPM_CONFIG_GLOBALCONFIG` env var already used by the `TfxInstaller@5` task in the `PublishToMarketplace` job (`package.json` and the copied `.npmrc` both live at the repo root, so the path is `$(Build.SourcesDirectory)/.npmrc`).