### PR TITLE
Use TfxInstaller task with job-level NPM_CONFIG_GLOBALCONFIG for authenticated feed

### DIFF
--- a/.pipelines/build.yml
+++ b/.pipelines/build.yml
@@ -148,8 +148,13 @@ extends:
               displayName: Authenticate npm to feed
               inputs:
                 workingFile: '$(Build.SourcesDirectory)/.npmrc'
-            - script: npm install -g tfx-cli --globalconfig $(Build.SourcesDirectory)/.npmrc
-              displayName: Install TFX
+            - task: TfxInstaller@5
+              displayName: 'Install TFX CLI'
+              env:
+                NPM_CONFIG_GLOBALCONFIG: $(Build.SourcesDirectory)/.npmrc
+              inputs:
+                version: '0.*'
+                checkLatest: true
             - task: 1ES.PublishAzureDevOpsExtension@1
               displayName: 'Publish the production extension to the Marketplace'
               inputs:

--- a/.pipelines/build.yml
+++ b/.pipelines/build.yml
@@ -129,6 +129,8 @@ extends:
         jobs:
         - job: PublishToMarketplaceJob
           displayName: Publish to Marketplace
+          variables:
+            NPM_CONFIG_GLOBALCONFIG: $(Build.SourcesDirectory)/.npmrc
           pool:
             name: Azure-Pipelines-1ESPT-ExDShared
             image: ubuntu-latest
@@ -150,8 +152,6 @@ extends:
                 workingFile: '$(Build.SourcesDirectory)/.npmrc'
             - task: TfxInstaller@5
               displayName: 'Install TFX CLI'
-              env:
-                NPM_CONFIG_GLOBALCONFIG: $(Build.SourcesDirectory)/.npmrc
               inputs:
                 version: '0.*'
                 checkLatest: true


### PR DESCRIPTION
Restores the `TfxInstaller@5` task for installing the TFX CLI in the `PublishToMarketplaceJob`, instead of a raw `npm install -g tfx-cli --globalconfig ...` script.

Because `TfxInstaller` implicitly runs `npm install -g tfx-cli`, it wouldn't otherwise respect the repo's `.npmrc`. To avoid a public fetch, `NPM_CONFIG_GLOBALCONFIG` is set as a job-level variable pointing at `$(Build.SourcesDirectory)/.npmrc`, so the whole job (including the task's implicit install) uses the authenticated feed.